### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/scripts/blocks.ts
+++ b/scripts/blocks.ts
@@ -67,14 +67,14 @@ const getItemNameForBlock = (name: string) => {
   });
   const dataPage = await browser.newPage();
   console.log("Opening data page...");
-  await dataPage.goto("https://minecraft.gamepedia.com/Java_Edition_data_values");
+  await dataPage.goto("https://minecraft.wiki/w/Java_Edition_data_values");
   console.log("Data page loaded");
   await dataPage.waitForSelector("div[data-page='Java Edition data values/Blocks'] .jslink");
   await dataPage.click("div[data-page='Java Edition data values/Blocks'] .jslink");
   await dataPage.waitForSelector("a[title='Acacia Button']");
   console.log("Blocks table loaded");
   const explosionPage = await browser.newPage();
-  await explosionPage.goto("https://minecraft.gamepedia.com/Explosion", {
+  await explosionPage.goto("https://minecraft.wiki/w/Explosion", {
     waitUntil: "domcontentloaded",
   });
   console.log("Explosion page loaded");
@@ -117,7 +117,7 @@ const getItemNameForBlock = (name: string) => {
           }
           const url: string =
             name === "Beetroots"
-              ? "https://minecraft.gamepedia.com/Beetroot_Seeds"
+              ? "https://minecraft.wiki/w/Beetroot_Seeds"
               : await (await a.getProperty("href")).jsonValue();
           blockPage = await browser.newPage();
           await blockPage.goto(url, {

--- a/scripts/blocks.ts
+++ b/scripts/blocks.ts
@@ -615,7 +615,7 @@ const getItemNameForBlock = (name: string) => {
           if (missingAttribute("tool")) return;
 
           // disabled requiresTool and requiresSilkTouch since the information has been moved to
-          // https://minecraft.fandom.com/wiki/Breaking and https://minecraft.fandom.com/wiki/Silk_Touch
+          // https://minecraft.wiki/w/Breaking and https://minecraft.wiki/w/Silk_Touch
           // TODO: add hardness instead of requiresTool?
 
           try {

--- a/scripts/items.ts
+++ b/scripts/items.ts
@@ -25,7 +25,7 @@ const writeItems = (items: Item[]) => {
   });
   const dataPage = await browser.newPage();
   console.log("Opening data page...");
-  dataPage.goto("https://minecraft.fandom.com/wiki/Java_Edition_data_values", {
+  dataPage.goto("https://minecraft.wiki/w/Java_Edition_data_values", {
     timeout: 0,
   });
   await dataPage.waitForSelector("div[data-page='Java Edition data values/Items'] .jslink");
@@ -88,7 +88,7 @@ const writeItems = (items: Item[]) => {
           );
           const url: string =
             name === "Tropical Fish"
-              ? "https://minecraft.fandom.com/wiki/Tropical_Fish_(item)"
+              ? "https://minecraft.wiki/w/Tropical_Fish_(item)"
               : await (await (await row.$("a[title]")).getProperty("href")).jsonValue();
           const itemPage = await browser.newPage();
           await itemPage.goto(url, { timeout: 0 });
@@ -329,7 +329,7 @@ const writeItems = (items: Item[]) => {
   await Promise.all(
     pages.map(async ({ page, namespacedId, stackSize, renewable, filter }) => {
       const itemPage = await browser.newPage();
-      await itemPage.goto("https://minecraft.fandom.com/wiki/" + page);
+      await itemPage.goto("https://minecraft.wiki/w/" + page);
       await itemPage.waitForSelector(".invslot-item");
       const newItems = (
         await itemPage.evaluate(() => {

--- a/scripts/recipes.ts
+++ b/scripts/recipes.ts
@@ -12,7 +12,7 @@ import { sortByKey } from "../utils";
   });
   const page = await browser.newPage();
   console.log("Opening crafting page...");
-  await page.goto("https://minecraft.fandom.com/wiki/Crafting", {
+  await page.goto("https://minecraft.wiki/w/Crafting", {
     waitUntil: "domcontentloaded",
   });
   console.log("Crafting page loaded");


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki